### PR TITLE
Also match a capitalized password prompt

### DIFF
--- a/lib/sshkit/sudo/backends_ext/netssh.rb
+++ b/lib/sshkit/sudo/backends_ext/netssh.rb
@@ -30,7 +30,7 @@ module SSHKit
                   if data =~ /Sorry.*\stry\sagain/
                     SSHKit::Sudo.password_cache[password_cache_key(cmd.host)] = nil
                   end
-                  if data =~ /password.*:/
+                  if data =~ /[Pp]assword.*:/
                     key = password_cache_key(cmd.host)
                     pass = SSHKit::Sudo.password_cache[key]
                     unless pass


### PR DESCRIPTION
sudo 1.8.12 from http://www.sudo.ws/ uses a capitalized "Password:" prompt instead of an
all-lowercase password prompt.

I believe the code in capistrano 2 handled this situation by using the -p option to set an explicit prompt and then matching on it, but I've opted for this approach since it is less invasive and probably works in most cases.
